### PR TITLE
Standardized spacing after periods and line length

### DIFF
--- a/acceptance.txt
+++ b/acceptance.txt
@@ -1,7 +1,8 @@
 Hello [[name]],
 
-Thank you for submitting your submission(s) to Lone Star PHP.  This year we
-received over 400 submissions.  With all the great submissions came many very difficult choices.
+Thank you for submitting your submission(s) to Lone Star PHP. This year we
+received over 400 submissions. With all the great submissions came many very
+difficult choices.
 
 We are excited to let you know that your following submission(s) were accepted:
 [[sessions]]
@@ -13,8 +14,8 @@ With the selected submission(s) above we are able to offer you:
 - Speaker's Dinner
 - Full access to the conference
 
-Other travel considerations will be made on an as-needed basis. A Lone Star PHP organizer
-will be contacting you soon to book you air travel.
+Other travel considerations will be made on an as-needed basis. A Lone Star PHP
+organizer will be contacting you soon to book you air travel.
 
 === What We Need ===
 If you could provide us with the following information:
@@ -30,7 +31,7 @@ submission, please feel free to send that as well.
 We ask that you please reply to this email no later than Friday, January 9th, and
 let us know if you have accepted this speaking opportunity.
 
-Also, feel free to announce your acceptance on twitter!  Our hash tag is #lsp15
+Also, feel free to announce your acceptance on twitter! Our hash tag is #lsp15
 
 We can't wait to hear back from you and see you in Dallas!
 

--- a/rejection.txt
+++ b/rejection.txt
@@ -1,9 +1,8 @@
 Hello [[name]],
 
-Thank you for submitting your ideas to Lone Star PHP!  This year we
-received over 400 submissions.  With all the great submissions
-came many very difficult choices. Unfortunately, the sessions you submitted
-were not accepted this year.
+Thank you for submitting your ideas to Lone Star PHP! This year we received over
+400 submissions. With all the great submissions came many very difficult
+choices. Unfortunately, the sessions you submitted were not accepted this year.
 
 There were so many great submissions but with limited speaker slots, there were
 many we just couldn't include. Coming up with a conference schedule is never
@@ -12,8 +11,8 @@ and challenging to those who will attend.
 
 We encourage you to continue submitting your talks and ideas to other
 conferences and to stay involved in the PHP community. We would still love for
-you to attend Lone Star PHP this year, though. Early Bird tickets are still on sale,
-so be sure to pick up your passes at this limited-time discounted rate!
+you to attend Lone Star PHP this year, though. Early Bird tickets are still on
+sale, so be sure to pick up your passes at this limited-time discounted rate!
 
 -- Lone Star PHP Team
 http://lonestarphp.com


### PR DESCRIPTION
Most lines were around 80 characters. Some were much longer, some were much
shorter. Standardized closer to 80.

Some periods had two spaces after, most had one. Standardized on one space
after periods.
